### PR TITLE
Removed unnecessarily destructured 'method'

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ In this step, we'll create custom middleware that will check to see if the sessi
 
 ```js
 module.exports = function( req, res, next ) {
-  const { session, method } = req;
+  const { session } = req;
   if ( !session.user ) {
     session.user = {
       messages: []


### PR DESCRIPTION
Step 2 Solution originally destructured `session` and `method`, but `method` isn't being used.